### PR TITLE
Implemented API endpoints

### DIFF
--- a/Touch-N-Stars/Helper/CoreUtility.cs
+++ b/Touch-N-Stars/Helper/CoreUtility.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+
+namespace TouchNStars.Helper;
+
+public static class CoreUtility {
+    public const string BASE_API_URL = "http://localhost:1888/v2/api";
+
+    public static readonly string CachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "NINA", "FramingAssistantCache");
+    public static readonly string LogPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "NINA", "Logs");
+    public static readonly string XMLFilePath = Path.Combine(CachePath, "CacheInfo.xml");
+
+    public static double HmsToDegrees(string hms) {
+        string[] hmsParts = hms.Split(':');
+        if (hmsParts.Length == 3) {
+            return (double.Parse(hmsParts[0]) * 15) + (double.Parse(hmsParts[1]) * (15.0 / 60)) + (double.Parse(hmsParts[2]) * (15.0 / 3600));
+        } else {
+            throw new ArgumentException("HMS string must be in the format HH:MM:SS, was: " + hms);
+        }
+    }
+
+    public static double DmsToDegrees(string dms) {
+        int sign = dms.StartsWith('-') ? -1 : 1;
+        string stripped = dms.Remove(0, 1);
+
+        string[] dmsParts = stripped.Split(':');
+
+        if (dmsParts.Length == 3) {
+            return (double.Parse(dmsParts[0]) + (double.Parse(dmsParts[1]) / 60) + (double.Parse(dmsParts[2]) / 3600)) * sign;
+        } else {
+            throw new ArgumentException("DMS string must be in the format DD:MM:SS.s, was: " + dms);
+        }
+    }
+}

--- a/Touch-N-Stars/Options.xaml
+++ b/Touch-N-Stars/Options.xaml
@@ -11,10 +11,6 @@
                 <TextBlock Text="Default Notification Message" />
                 <TextBox MinWidth="50" Text="{Binding DefaultNotificationMessage}" />
             </StackPanel>
-            <StackPanel Orientation="Horizontal">
-                <TextBlock Text="Profile Specific Notification Message" />
-                <TextBox MinWidth="50" Text="{Binding ProfileSpecificNotificationMessage}" />
-            </StackPanel>
         </StackPanel>
     </DataTemplate>
 </ResourceDictionary>

--- a/Touch-N-Stars/Properties/AssemblyInfo.cs
+++ b/Touch-N-Stars/Properties/AssemblyInfo.cs
@@ -24,7 +24,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright © 2025 Johannes M, Christian Palm")]
 
 // The minimum Version of N.I.N.A. that this plugin is compatible with
-[assembly: AssemblyMetadata("MinimumApplicationVersion", "3.0.0.2017")]
+[assembly: AssemblyMetadata("MinimumApplicationVersion", "3.1.2.9001")]
 
 // The license your plugin code is using
 [assembly: AssemblyMetadata("License", "MPL-2.0")]

--- a/Touch-N-Stars/Server/Controller.cs
+++ b/Touch-N-Stars/Server/Controller.cs
@@ -1,10 +1,19 @@
 using EmbedIO;
 using EmbedIO.Routing;
 using EmbedIO.WebApi;
+using NINA.Astrometry;
+using NINA.Core.Utility;
+using NINA.WPF.Base.SkySurvey;
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
-using TouchNStars.Helper;
+using System.Windows.Media.Imaging;
+using TouchNStars.Utility;
 
 namespace TouchNStars.Server;
 
@@ -19,11 +28,18 @@ public class NGCSearchResult {
     public double Dec { get; set; }
 }
 
+public class ApiResponse {
+    public bool Success { get; set; }
+    public string Response { get; set; }
+    public string Error { get; set; }
+    public int StatusCode { get; set; }
+    public string Type { get; set; }
+}
+
 public class Controller : WebApiController {
 
     private object lockObj = new object();
 
-    private object searchResultsCache = null; // unsure which type this will be
     private GuiderData guiderData = new GuiderData();
     private bool afRun = false;
     private bool afError = false;
@@ -33,32 +49,145 @@ public class Controller : WebApiController {
     private bool wshvActive = false;
     private int wshvPort = 80;
 
+    private static readonly List<string> excluded_members = new List<string>() { "GetEquipment", "RequestAll", "LoadPlugin" };
 
-    [Route(HttpVerbs.Get, "/api/logs")]
-    public string GetRecentLogs([QueryField] int count, [QueryField] string level) {
-        return "Hello World";
+
+    [Route(HttpVerbs.Get, "/logs")]
+    public List<Hashtable> GetRecentLogs([QueryField] int count, [QueryField] string level) {
+        List<Hashtable> logs = new List<Hashtable>();
+
+        if (level.Equals("ERROR") || level.Equals("WARNING") || level.Equals("INFO") || level.Equals("DEBUG")) {
+            string currentLogFile = Directory.GetFiles(CoreUtility.LogPath).OrderByDescending(File.GetCreationTime).First();
+
+            string[] logLines = [];
+
+            using (var stream = new FileStream(currentLogFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)) {
+                using (var reader = new StreamReader(stream)) {
+                    string content = reader.ReadToEnd();
+                    logLines = content.Split('\n');
+                }
+            }
+
+            List<string> filteredLogLines = new List<string>();
+            foreach (string line in logLines) {
+                bool valid = true;
+
+                if (!line.Contains('|' + level + '|')) {
+                    valid = false;
+                }
+                foreach (string excluded_member in excluded_members) {
+                    if (line.Contains(excluded_member)) {
+                        valid = false;
+                    }
+                }
+                if (valid) {
+                    filteredLogLines.Add(line);
+                }
+            }
+            IEnumerable<string> lines = filteredLogLines.TakeLast(count);
+            foreach (string line in lines) {
+                string[] parts = line.Split('|');
+                if (parts.Length >= 6) {
+                    logs.Add(new Hashtable() {
+                        { "timestamp", parts[0] },
+                        { "level", parts[1] },
+                        { "source", parts[2] },
+                        { "member", parts[3] },
+                        { "line", parts[4] },
+                        { "message", string.Join('|', parts.Skip(5)).Trim() }
+                    });
+                }
+            }
+        }
+        return logs;
     }
 
-    [Route(HttpVerbs.Get, "/api/wshv")]
+    [Route(HttpVerbs.Get, "/wshv")]
     public object GetWshvData() {
         lock (lockObj) {
             return new Dictionary<string, object>() { { "wshvActive", wshvActive }, { "wshvPort", wshvPort } };
         }
     }
 
-    [Route(HttpVerbs.Get, "/api/autofocus")]
-    public string ControlAutofocus() {
-        return "Hello World Autofocus";
+    [Route(HttpVerbs.Get, "/autofocus/{action}")]
+    public async Task<object> ControlAutofocus([QueryField] string action) {
+        string targetUrl = $"{CoreUtility.BASE_API_URL}/equipment/focuser/auto-focus";
+        bool info = action.Equals("info");
+        bool start = action.Equals("start");
+        bool stop = action.Equals("stopp");
+
+        if (info) {
+            return new Dictionary<string, object>() {
+                { "Success", true },
+                { "autofocus_running", afRun },
+                { "newAfGraph", newAfGraph },
+                { "afError", afError },
+                { "afErrorText", afErrorText },
+            };
+        }
+        if (start) {
+            afRun = true;
+            newAfGraph = false;
+            afError = false;
+            afErrorText = string.Empty;
+
+            try {
+                HttpClient client = new HttpClient();
+                HttpResponseMessage response = await client.GetAsync(targetUrl);
+
+                if (response.IsSuccessStatusCode) {
+                    ApiResponse apiResponse = await response.Content.ReadFromJsonAsync<ApiResponse>();
+                    if (apiResponse.Success) {
+                        return new Dictionary<string, object>() { { "message", "Autofokus gestartet" } };
+                    } else {
+                        return new Dictionary<string, object>() { { "message", $"Fehler beim Starten des Autofokus: {apiResponse.Error}" } };
+                    }
+                } else {
+                    return new Dictionary<string, object>() { { "message", $"Fehler beim Starten des Autofokus: {response.StatusCode}" } };
+                }
+            } catch (Exception ex) {
+                Logger.Error(ex);
+                HttpContext.Response.StatusCode = 500;
+                return new Dictionary<string, object>() { { "error", "Interner Fehler beim Starten des Autofokus" } };
+            }
+        }
+
+        if (stop) {
+            afRun = false;
+            newAfGraph = false;
+
+            try {
+                HttpClient client = new HttpClient();
+                HttpResponseMessage response = await client.GetAsync(targetUrl + "?cancel=true");
+
+                if (response.IsSuccessStatusCode) {
+                    ApiResponse apiResponse = await response.Content.ReadFromJsonAsync<ApiResponse>();
+                    if (apiResponse.Success) {
+                        return new Dictionary<string, object>() { { "message", "Autofokus gestoppt" } };
+                    } else {
+                        return new Dictionary<string, object>() { { "message", $"Fehler beim Stoppen des Autofokus: {apiResponse.Error}" } };
+                    }
+                } else {
+                    return new Dictionary<string, object>() { { "message", $"Fehler beim Stoppen des Autofokus: {response.StatusCode}" } };
+                }
+            } catch (Exception ex) {
+                Logger.Error(ex);
+                HttpContext.Response.StatusCode = 500;
+                return new Dictionary<string, object>() { { "error", "Interner Fehler beim Stopoen des Autofokus" } };
+            }
+        }
+
+        return new Dictionary<string, object>() { { "error", "Ungültige Anfrage" } };
     }
 
-    [Route(HttpVerbs.Get, "/api/guider-data")]
+    [Route(HttpVerbs.Get, "/guider-data")]
     public object GetGuiderData() {
         lock (lockObj) {
             return guiderData;
         }
     }
 
-    [Route(HttpVerbs.Get, "/api/ngc/search")]
+    [Route(HttpVerbs.Get, "/ngc/search")]
     public async Task<object> SearcgNGC([QueryField(true)] string query, [QueryField] int limit) {
 
         TouchNStars.Mediators.DeepSkyObjectSearchVM.Limit = limit;
@@ -78,19 +207,33 @@ public class Controller : WebApiController {
         return results;
     }
 
-    [Route(HttpVerbs.Get, "/api/ngc/cache")] // can we omit the following two methods?
-    public string GetCachedNGCResults() {
-        return "Hello World NGC Cache";
-    }
+    [Route(HttpVerbs.Get, "/targetpic")]
+    public async Task FetchTargetPicture([QueryField(true)] int width, [QueryField(true)] int height, [QueryField(true)] double fov, [QueryField(true)] double ra, [QueryField(true)] double dec, [QueryField] bool useCache) {
+        try {
+            HttpContext.Response.ContentType = "image/jpeg";
+            if (useCache) {
+                CacheSkySurveyImageFactory factory = new CacheSkySurveyImageFactory(width, height, new CacheSkySurvey(CoreUtility.CachePath));
+                BitmapSource source = factory.Render(new Coordinates(Angle.ByDegree(ra), Angle.ByDegree(dec), Epoch.J2000), fov, 0);
 
-    [Route(HttpVerbs.Post, "/api/ngc/cache")]
-    public string UpdateCachedNGCResults() {
-        // HttpContext.GetRequestBodyAsStringAsync()
-        return "Hello World NGC Cache";
-    }
+                JpegBitmapEncoder encoder = new JpegBitmapEncoder();
+                encoder.QualityLevel = 100;
+                using (MemoryStream stream = new MemoryStream()) {
+                    encoder.Frames.Add(BitmapFrame.Create(source));
+                    encoder.Save(stream);
+                    stream.Position = 0;
+                    Response.OutputStream.Write(stream.ToArray(), 0, (int)stream.Length);
+                }
+            } else {
+                HttpClient client = new HttpClient();
+                byte[] image = await client.GetByteArrayAsync($"{CoreUtility.Hips2FitsUrl}?width={width}&height={height}&fov={fov}&ra={ra}&dec={dec}&hips=CDS/P/DSS2/color&projection=STG&format=jpg");
+                Response.OutputStream.Write(image, 0, image.Length);
 
-    [Route(HttpVerbs.Get, "/api/targetpic")]
-    public string FetchTargetPicture([QueryField(true)] int width, [QueryField(true)] int height, [QueryField(true)] float fov, [QueryField(true)] string ra, [QueryField(true)] string dec) {
-        return "Hello World Target Picture";
+                client.Dispose();
+            }
+
+        } catch (Exception ex) {
+            Logger.Error(ex);
+            throw;
+        }
     }
 }

--- a/Touch-N-Stars/Server/Controller.cs
+++ b/Touch-N-Stars/Server/Controller.cs
@@ -1,0 +1,96 @@
+using EmbedIO;
+using EmbedIO.Routing;
+using EmbedIO.WebApi;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using TouchNStars.Helper;
+
+namespace TouchNStars.Server;
+
+public class GuiderData {
+    public List<double> RADistanceRaw { get; set; }
+    public List<double> DECDistanceRaw { get; set; }
+}
+
+public class NGCSearchResult {
+    public string Name { get; set; }
+    public double RA { get; set; }
+    public double Dec { get; set; }
+}
+
+public class Controller : WebApiController {
+
+    private object lockObj = new object();
+
+    private object searchResultsCache = null; // unsure which type this will be
+    private GuiderData guiderData = new GuiderData();
+    private bool afRun = false;
+    private bool afError = false;
+    private string afErrorText = string.Empty;
+    private bool newAfGraph = false;
+    private DateTime lastAfTimestamp = DateTime.MinValue;
+    private bool wshvActive = false;
+    private int wshvPort = 80;
+
+
+    [Route(HttpVerbs.Get, "/api/logs")]
+    public string GetRecentLogs([QueryField] int count, [QueryField] string level) {
+        return "Hello World";
+    }
+
+    [Route(HttpVerbs.Get, "/api/wshv")]
+    public object GetWshvData() {
+        lock (lockObj) {
+            return new Dictionary<string, object>() { { "wshvActive", wshvActive }, { "wshvPort", wshvPort } };
+        }
+    }
+
+    [Route(HttpVerbs.Get, "/api/autofocus")]
+    public string ControlAutofocus() {
+        return "Hello World Autofocus";
+    }
+
+    [Route(HttpVerbs.Get, "/api/guider-data")]
+    public object GetGuiderData() {
+        lock (lockObj) {
+            return guiderData;
+        }
+    }
+
+    [Route(HttpVerbs.Get, "/api/ngc/search")]
+    public async Task<object> SearcgNGC([QueryField(true)] string query, [QueryField] int limit) {
+
+        TouchNStars.Mediators.DeepSkyObjectSearchVM.Limit = limit;
+        TouchNStars.Mediators.DeepSkyObjectSearchVM.TargetName = query; // Setting the target name automatically starts the search
+
+        await TouchNStars.Mediators.DeepSkyObjectSearchVM.TargetSearchResult.Task; // Wait for the search to finsish
+        List<NGCSearchResult> results = new List<NGCSearchResult>();
+
+        foreach (var result in TouchNStars.Mediators.DeepSkyObjectSearchVM.TargetSearchResult.Result) { // bring the results in a better format
+            results.Add(new NGCSearchResult() {
+                Name = result.Column1,
+                RA = CoreUtility.HmsToDegrees(result.Column2),
+                Dec = CoreUtility.DmsToDegrees(result.Column3.Replace(" ", "").Replace('°', ':').Replace('\'', ':').Replace("\"", "")) // maybe use reflection to directly get the coordinates
+            });
+        }
+
+        return results;
+    }
+
+    [Route(HttpVerbs.Get, "/api/ngc/cache")] // can we omit the following two methods?
+    public string GetCachedNGCResults() {
+        return "Hello World NGC Cache";
+    }
+
+    [Route(HttpVerbs.Post, "/api/ngc/cache")]
+    public string UpdateCachedNGCResults() {
+        // HttpContext.GetRequestBodyAsStringAsync()
+        return "Hello World NGC Cache";
+    }
+
+    [Route(HttpVerbs.Get, "/api/targetpic")]
+    public string FetchTargetPicture([QueryField(true)] int width, [QueryField(true)] int height, [QueryField(true)] float fov, [QueryField(true)] string ra, [QueryField(true)] string dec) {
+        return "Hello World Target Picture";
+    }
+}

--- a/Touch-N-Stars/Server/TouchNStarsServer.cs
+++ b/Touch-N-Stars/Server/TouchNStarsServer.cs
@@ -17,15 +17,15 @@ namespace TouchNStars.Server {
             WebServer = new WebServer(o => o
                 .WithUrlPrefix($"http://*:{Port}")
                 .WithMode(HttpListenerMode.EmbedIO))
-                .WithWebApi("/", m => m.WithController<Controller>()) // Register the controller, which will be used to handle all the api requests which were previously in server.py
+                .WithWebApi("/api", m => m.WithController<Controller>()) // Register the controller, which will be used to handle all the api requests which were previously in server.py
                 .WithModule(new RedirectModule("/", "/app", request => request.RequestedPath.Equals("/"))); // Automatically redirect to user to the app, so the user doesn't have to enter /
         }
 
         public void Start() {
             try {
-                Logger.Debug("Creating Webserver");
+                Logger.Debug("Creating Touch-N-Stars Webserver");
                 CreateServer();
-                Logger.Info("Starting Webserver");
+                Logger.Info("Starting Touch-N-Stars Webserver");
                 if (WebServer != null) {
                     serverThread = new Thread(() => APITask(WebServer)) {
                         Name = "Touch-N-Stars API Thread"

--- a/Touch-N-Stars/Server/TouchNStarsServer.cs
+++ b/Touch-N-Stars/Server/TouchNStarsServer.cs
@@ -1,0 +1,66 @@
+using EmbedIO;
+using EmbedIO.Actions;
+using EmbedIO.WebApi;
+using NINA.Core.Utility;
+using NINA.Core.Utility.Notification;
+using System;
+using System.Threading;
+
+namespace TouchNStars.Server {
+    public class TouchNStarsServer {
+        private Thread serverThread;
+        private CancellationTokenSource apiToken;
+        public WebServer WebServer;
+        public readonly int Port = 5000;
+
+        public void CreateServer() {
+            WebServer = new WebServer(o => o
+                .WithUrlPrefix($"http://*:{Port}")
+                .WithMode(HttpListenerMode.EmbedIO))
+                .WithWebApi("/", m => m.WithController<Controller>()) // Register the controller, which will be used to handle all the api requests which were previously in server.py
+                .WithModule(new RedirectModule("/", "/app", request => request.RequestedPath.Equals("/"))); // Automatically redirect to user to the app, so the user doesn't have to enter /
+        }
+
+        public void Start() {
+            try {
+                Logger.Debug("Creating Webserver");
+                CreateServer();
+                Logger.Info("Starting Webserver");
+                if (WebServer != null) {
+                    serverThread = new Thread(() => APITask(WebServer)) {
+                        Name = "Touch-N-Stars API Thread"
+                    };
+                    // serverThread.SetApartmentState(ApartmentState.STA);
+                    serverThread.Start();
+                }
+            } catch (Exception ex) {
+                Logger.Error($"failed to start web server: {ex}");
+            }
+        }
+
+        public void Stop() {
+            try {
+                apiToken?.Cancel();
+                WebServer?.Dispose();
+                WebServer = null;
+            } catch (Exception ex) {
+                Logger.Error($"failed to stop API: {ex}");
+            }
+        }
+
+        // [STAThread]
+        private void APITask(WebServer server) {
+            // string ipAdress = CoreUtility.GetLocalNames()["IPADRESS"];
+            // Logger.Info($"starting web server, listening at {ipAdress}:{Port}");
+            Logger.Info("Touch-N-Stars Webserver starting");
+
+            try {
+                apiToken = new CancellationTokenSource();
+                server.RunAsync(apiToken.Token).Wait();
+            } catch (Exception ex) {
+                Logger.Error($"failed to start web server: {ex}");
+                Notification.ShowError($"Failed to start web server, see NINA log for details");
+            }
+        }
+    }
+}

--- a/Touch-N-Stars/Touch-N-Stars.csproj
+++ b/Touch-N-Stars/Touch-N-Stars.csproj
@@ -10,6 +10,7 @@
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="EmbedIO" Version="3.5.2" />
     <PackageReference Include="NINA.Plugin" Version="3.0.0.2017-beta" />
   </ItemGroup>
   <PropertyGroup />

--- a/Touch-N-Stars/Touch-N-Stars.csproj
+++ b/Touch-N-Stars/Touch-N-Stars.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="EmbedIO" Version="3.5.2" />
     <PackageReference Include="NINA.Plugin" Version="3.0.0.2017-beta" />
+    <PackageReference Include="NINA.WPF.Base" Version="3.1.2.9001" />
   </ItemGroup>
   <PropertyGroup />
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/Touch-N-Stars/TouchNStars.cs
+++ b/Touch-N-Stars/TouchNStars.cs
@@ -1,92 +1,48 @@
 ﻿using NINA.Core.Utility;
-using NINA.Image.ImageData;
 using NINA.Plugin;
 using NINA.Plugin.Interfaces;
-using NINA.Profile;
 using NINA.Profile.Interfaces;
-using NINA.WPF.Base.Interfaces.Mediator;
 using NINA.WPF.Base.Interfaces.ViewModel;
-using System;
 using System.ComponentModel;
 using System.ComponentModel.Composition;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using TouchNStars.Server;
 using Settings = TouchNStars.Properties.Settings;
 
 namespace TouchNStars {
-    /// <summary>
-    /// This class exports the IPluginManifest interface and will be used for the general plugin information and options
-    /// The base class "PluginBase" will populate all the necessary Manifest Meta Data out of the AssemblyInfo attributes. Please fill these accoringly
-    /// 
-    /// An instance of this class will be created and set as datacontext on the plugin options tab in N.I.N.A. to be able to configure global plugin settings
-    /// The user interface for the settings will be defined by a DataTemplate with the key having the naming convention "TouchNStars_Options" where TouchNStars corresponds to the AssemblyTitle - In this template example it is found in the Options.xaml
-    /// </summary>
+
+    public class Mediators {
+        public readonly IDeepSkyObjectSearchVM DeepSkyObjectSearchVM;
+
+        public Mediators(IDeepSkyObjectSearchVM DeepSkyObjectSearchVM) {
+            this.DeepSkyObjectSearchVM = DeepSkyObjectSearchVM;
+        }
+    }
+
     [Export(typeof(IPluginManifest))]
     public class TouchNStars : PluginBase, INotifyPropertyChanged {
-        private readonly IPluginOptionsAccessor pluginSettings;
-        private readonly IProfileService profileService;
-        private readonly IImageSaveMediator imageSaveMediator;
+        private TouchNStarsServer server;
+
+        public static Mediators Mediators { get; private set; }
+
 
         [ImportingConstructor]
-        public TouchNStars(IProfileService profileService, IOptionsVM options, IImageSaveMediator imageSaveMediator) {
+        public TouchNStars(IProfileService profileService, IDeepSkyObjectSearchVM DeepSkyObjectSearchVM, IFramingAssistantVM framing) {
             if (Settings.Default.UpdateSettings) {
                 Settings.Default.Upgrade();
                 Settings.Default.UpdateSettings = false;
                 CoreUtil.SaveSettings(Settings.Default);
             }
-
-            // This helper class can be used to store plugin settings that are dependent on the current profile
-            this.pluginSettings = new PluginOptionsAccessor(profileService, Guid.Parse(this.Identifier));
-            this.profileService = profileService;
-            // React on a changed profile
-            profileService.ProfileChanged += ProfileService_ProfileChanged;
-
-            // Hook into image saving for adding FITS keywords or image file patterns
-            this.imageSaveMediator = imageSaveMediator;
-
-            // Run these handlers when an image is being saved
-            this.imageSaveMediator.BeforeImageSaved += ImageSaveMediator_BeforeImageSaved;
+            Mediators = new Mediators(DeepSkyObjectSearchVM);
+            server = new TouchNStarsServer();
+            server.Start();
         }
 
         public override Task Teardown() {
             // Make sure to unregister an event when the object is no longer in use. Otherwise garbage collection will be prevented.
-            profileService.ProfileChanged -= ProfileService_ProfileChanged;
-            imageSaveMediator.BeforeImageSaved -= ImageSaveMediator_BeforeImageSaved;
-
+            server.Stop();
             return base.Teardown();
-        }
-
-        private void ProfileService_ProfileChanged(object sender, EventArgs e) {
-            // Rase the event that this profile specific value has been changed due to the profile switch
-            RaisePropertyChanged(nameof(ProfileSpecificNotificationMessage));
-        }
-
-        private Task ImageSaveMediator_BeforeImageSaved(object sender, BeforeImageSavedEventArgs e) {
-            // Insert the example FITS keyword of a specific data type into the image metadata object prior to the file being saved
-            // FITS keywords have a maximum of 8 characters. Comments are options. Comments that are too long will be truncated.
-
-            string exampleKeywordComment = "This is a {0} keyword";
-
-            // string
-            string exampleStringKeywordName = "STRKEYWD";
-            string exampleStringKeywordValue = "Example";
-            e.Image.MetaData.GenericHeaders.Add(new StringMetaDataHeader(exampleStringKeywordName, exampleStringKeywordValue, string.Format(exampleKeywordComment, "string")));
-
-            // integer
-            string exampleIntKeywordName = "INTKEYWD";
-            int exampleIntKeywordValue = 5;
-            e.Image.MetaData.GenericHeaders.Add(new IntMetaDataHeader(exampleIntKeywordName, exampleIntKeywordValue, string.Format(exampleKeywordComment, "integer")));
-
-            // double
-            string exampleDoubleKeywordName = "DBLKEYWD";
-            double exampleDoubleKeywordValue = 1.3d;
-            e.Image.MetaData.GenericHeaders.Add(new DoubleMetaDataHeader(exampleDoubleKeywordName, exampleDoubleKeywordValue, string.Format(exampleKeywordComment, "double")));
-
-            // Classes also exist for other data types:
-            // BoolMetaDataHeader()
-            // DateTimeMetaDataHeader()
-
-            return Task.CompletedTask;
         }
 
         public string DefaultNotificationMessage {
@@ -96,16 +52,6 @@ namespace TouchNStars {
             set {
                 Settings.Default.DefaultNotificationMessage = value;
                 CoreUtil.SaveSettings(Settings.Default);
-                RaisePropertyChanged();
-            }
-        }
-
-        public string ProfileSpecificNotificationMessage {
-            get {
-                return pluginSettings.GetValueString(nameof(ProfileSpecificNotificationMessage), string.Empty);
-            }
-            set {
-                pluginSettings.SetValueString(nameof(ProfileSpecificNotificationMessage), value);
                 RaisePropertyChanged();
             }
         }

--- a/Touch-N-Stars/TouchNStars.cs
+++ b/Touch-N-Stars/TouchNStars.cs
@@ -1,4 +1,6 @@
-﻿using NINA.Core.Utility;
+﻿using ASCOM.Com;
+using NINA.Core.Utility;
+using NINA.Image.Interfaces;
 using NINA.Plugin;
 using NINA.Plugin.Interfaces;
 using NINA.Profile.Interfaces;
@@ -12,12 +14,11 @@ using Settings = TouchNStars.Properties.Settings;
 
 namespace TouchNStars {
 
-    public class Mediators {
-        public readonly IDeepSkyObjectSearchVM DeepSkyObjectSearchVM;
-
-        public Mediators(IDeepSkyObjectSearchVM DeepSkyObjectSearchVM) {
-            this.DeepSkyObjectSearchVM = DeepSkyObjectSearchVM;
-        }
+    public class Mediators(IDeepSkyObjectSearchVM DeepSkyObjectSearchVM, IImageDataFactory ImageDataFactory, IFramingAssistantVM framingAssistantVM, IProfileService profile) {
+        public readonly IDeepSkyObjectSearchVM DeepSkyObjectSearchVM = DeepSkyObjectSearchVM;
+        public readonly IImageDataFactory ImageDataFactory = ImageDataFactory;
+        public readonly IFramingAssistantVM FramingAssistantVM = framingAssistantVM;
+        public readonly IProfileService Profile = profile;
     }
 
     [Export(typeof(IPluginManifest))]
@@ -28,13 +29,13 @@ namespace TouchNStars {
 
 
         [ImportingConstructor]
-        public TouchNStars(IProfileService profileService, IDeepSkyObjectSearchVM DeepSkyObjectSearchVM, IFramingAssistantVM framing) {
+        public TouchNStars(IProfileService profileService, IDeepSkyObjectSearchVM DeepSkyObjectSearchVM, IImageDataFactory imageDataFactory, IFramingAssistantVM framingAssistantVM) {
             if (Settings.Default.UpdateSettings) {
                 Settings.Default.Upgrade();
                 Settings.Default.UpdateSettings = false;
                 CoreUtil.SaveSettings(Settings.Default);
             }
-            Mediators = new Mediators(DeepSkyObjectSearchVM);
+            Mediators = new Mediators(DeepSkyObjectSearchVM, imageDataFactory, framingAssistantVM, profileService);
             server = new TouchNStarsServer();
             server.Start();
         }

--- a/Touch-N-Stars/Utility/CoreUtility.cs
+++ b/Touch-N-Stars/Utility/CoreUtility.cs
@@ -1,14 +1,14 @@
 using System;
 using System.IO;
 
-namespace TouchNStars.Helper;
+namespace TouchNStars.Utility;
 
 public static class CoreUtility {
     public const string BASE_API_URL = "http://localhost:1888/v2/api";
 
     public static readonly string CachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "NINA", "FramingAssistantCache");
     public static readonly string LogPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "NINA", "Logs");
-    public static readonly string XMLFilePath = Path.Combine(CachePath, "CacheInfo.xml");
+    public static readonly string Hips2FitsUrl = "http://alaskybis.u-strasbg.fr/hips-image-services/hips2fits";
 
     public static double HmsToDegrees(string hms) {
         string[] hmsParts = hms.Split(':');


### PR DESCRIPTION
I implemented all api endpoints, only small changes to responses or endpoints were necessary. The background tasks are not implemented yet.

- `ngc/search` now has a list containing multiple search results. These have the following fields: `Name`, `RA` and `Dec`
- introduced a new query parameter to `/targetpic` `useCache`. This determines whether the Cache or the hips2fits server should be used.
- The `autofocus` endpoint now accepts its parameter in the following form: `/autofocus/{action}` with action being either `info`, `start` or `stopp`

I think these are all changes